### PR TITLE
feat: multi-platform plugin support (Claude Code, Cursor, Codex, OpenCode, Gemini)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "master-skill",
+  "description": "Chinese Buddhist Master AI Skills — 8 historical masters with source-cited teachings",
+  "owner": {
+    "name": "xr843",
+    "email": "xr843@users.noreply.github.com"
+  },
+  "plugins": [
+    {
+      "name": "master-skill",
+      "description": "Chinese Buddhist Master AI teaching personas — 8 prebuilt masters with CBETA-cited doctrinal responses, RAG-grounded in FoJin knowledge graph",
+      "version": "0.3.0",
+      "source": "./",
+      "author": {
+        "name": "xr843",
+        "email": "xr843@users.noreply.github.com"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "master-skill",
+  "description": "Chinese Buddhist Master AI teaching personas — 8 prebuilt masters with CBETA-cited doctrinal responses, RAG-grounded in FoJin knowledge graph",
+  "version": "0.3.0",
+  "author": {
+    "name": "xr843",
+    "email": "xr843@users.noreply.github.com"
+  },
+  "homepage": "https://github.com/xr843/Master-skill",
+  "repository": "https://github.com/xr843/Master-skill",
+  "license": "MIT",
+  "keywords": [
+    "buddhism",
+    "chinese-buddhism",
+    "ai-persona",
+    "digital-humanities",
+    "rag",
+    "cbeta",
+    "fojin",
+    "agent-skills"
+  ]
+}

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,0 +1,45 @@
+# Installing Master-skill for Codex
+
+## Quick Install
+
+```bash
+# Clone the repository
+git clone https://github.com/xr843/Master-skill.git ~/.codex/master-skill
+
+# Create skills symlink
+ln -sf ~/.codex/master-skill/prebuilt ~/.agents/skills/master-skill
+ln -sf ~/.codex/master-skill/SKILL.md ~/.agents/skills/create-master/SKILL.md
+```
+
+Restart Codex to discover the new skills.
+
+## Windows (PowerShell)
+
+```powershell
+git clone https://github.com/xr843/Master-skill.git "$env:USERPROFILE\.codex\master-skill"
+cmd /c mklink /J "$env:USERPROFILE\.agents\skills\master-skill" "$env:USERPROFILE\.codex\master-skill\prebuilt"
+```
+
+## Available Skills After Install
+
+- `/xuanzang` — Xuanzang (Yogacara)
+- `/kumarajiva` — Kumarajiva (Madhyamaka)
+- `/huineng` — Huineng (Chan/Zen)
+- `/zhiyi` — Zhiyi (Tiantai)
+- `/fazang` — Fazang (Huayan)
+- `/yinguang` — Yinguang (Pure Land)
+- `/ouyi` — Ouyi (Tiantai-Pure Land)
+- `/xuyun` — Xuyun (Chan, Five Schools)
+- `/compare-masters` — Multi-tradition comparison
+- `/create-master` — Generate new master
+
+## Tool Mapping
+
+| Skill references | Codex equivalent |
+|---|---|
+| `Read` | `read_file` |
+| `Write` | `write_file` |
+| `Edit` | `edit_file` |
+| `Bash` | `shell` |
+| `Grep` | `grep` |
+| `Glob` | `glob` |

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "master-skill",
+  "displayName": "Master Skill",
+  "description": "Chinese Buddhist Master AI teaching personas — 8 prebuilt masters with CBETA-cited doctrinal responses",
+  "version": "0.3.0",
+  "author": {
+    "name": "xr843",
+    "email": "xr843@users.noreply.github.com"
+  },
+  "homepage": "https://github.com/xr843/Master-skill",
+  "repository": "https://github.com/xr843/Master-skill",
+  "license": "MIT",
+  "keywords": [
+    "buddhism",
+    "ai-persona",
+    "digital-humanities",
+    "rag",
+    "agent-skills"
+  ],
+  "skills": "./prebuilt/",
+  "hooks": "./hooks/hooks-cursor.json"
+}

--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -1,0 +1,46 @@
+# Installing Master-skill for OpenCode
+
+## Quick Install
+
+Add to your `opencode.json`:
+
+```json
+{
+  "plugin": ["master-skill@git+https://github.com/xr843/Master-skill.git"]
+}
+```
+
+OpenCode will automatically install and register all skills.
+
+## Pin a Version
+
+```json
+{
+  "plugin": ["master-skill@git+https://github.com/xr843/Master-skill.git#v0.3.0"]
+}
+```
+
+## Available Skills After Install
+
+- `/xuanzang` — Xuanzang (Yogacara)
+- `/kumarajiva` — Kumarajiva (Madhyamaka)
+- `/huineng` — Huineng (Chan/Zen)
+- `/zhiyi` — Zhiyi (Tiantai)
+- `/fazang` — Fazang (Huayan)
+- `/yinguang` — Yinguang (Pure Land)
+- `/ouyi` — Ouyi (Tiantai-Pure Land)
+- `/xuyun` — Xuyun (Chan, Five Schools)
+- `/compare-masters` — Multi-tradition comparison
+- `/create-master` — Generate new master
+
+## Tool Mapping
+
+| Skill references | OpenCode equivalent |
+|---|---|
+| `Read` | `read_file` |
+| `Write` | `write_file` |
+| `Edit` | `edit_file` |
+| `Bash` | `shell` |
+| `Grep` | `grep` |
+| `Glob` | `glob` |
+| `Skill` | `skill` (native) |

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,0 +1,9 @@
+{
+  "files": [
+    {"path": "package.json", "field": "version"},
+    {"path": ".claude-plugin/plugin.json", "field": "version"},
+    {"path": ".claude-plugin/marketplace.json", "field": "plugins.0.version"},
+    {"path": ".cursor-plugin/plugin.json", "field": "version"},
+    {"path": "gemini-extension.json", "field": "version"}
+  ]
+}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,2 @@
+@./SKILL.md
+@./prebuilt/compare/SKILL.md

--- a/README.md
+++ b/README.md
@@ -88,23 +88,40 @@ npx master-skill install --all
 npx master-skill list
 ```
 
-**Claude Code**
+**Claude Code（插件方式）**
 
 ```bash
+# 即将上线插件市场，目前使用手动安装：
 git clone https://github.com/xr843/Master-skill ~/Master-skill
 cd ~/Master-skill && pip install -r requirements.txt
 for d in prebuilt/*/; do ln -sf "$(pwd)/$d" ~/.claude/skills/"$(basename $d)"; done
 ln -sf "$(pwd)" ~/.claude/skills/create-master
 ```
 
-**Codex CLI**
+**Cursor**
 
 ```bash
 git clone https://github.com/xr843/Master-skill ~/Master-skill
-cd ~/Master-skill && pip install -r requirements.txt
-for d in prebuilt/*/; do ln -sf "$(pwd)/$d" ~/.codex/skills/"$(basename $d)"; done
-ln -sf "$(pwd)" ~/.codex/skills/create-master
+# Cursor 自动检测 .cursor-plugin/plugin.json 并注册技能
 ```
+
+**OpenCode**
+
+在 `opencode.json` 中添加：
+
+```json
+{
+  "plugin": ["master-skill@git+https://github.com/xr843/Master-skill.git"]
+}
+```
+
+**Codex CLI**
+
+参见 [.codex/INSTALL.md](.codex/INSTALL.md)
+
+**Gemini CLI**
+
+本项目包含 `gemini-extension.json` 和 `GEMINI.md`，Gemini CLI 自动发现并加载。
 
 ### 使用预置法师
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -76,39 +76,33 @@ No installation required — try all pre-built masters directly in your browser:
 
 ### Installation
 
+**NPX (recommended)**
+
+```bash
+npx master-skill install --all    # Install all 8 masters
+npx master-skill list             # List available masters
+```
+
 **Claude Code**
 
 ```bash
 git clone https://github.com/xr843/Master-skill ~/Master-skill
 cd ~/Master-skill && pip install -r requirements.txt
-# Register skills (symlink to ~/.claude/skills/)
 for d in prebuilt/*/; do ln -sf "$(pwd)/$d" ~/.claude/skills/"$(basename $d)"; done
 ln -sf "$(pwd)" ~/.claude/skills/create-master
 ```
 
-**Codex CLI**
+**Cursor** — Clone the repo; Cursor auto-detects `.cursor-plugin/plugin.json`.
 
-```bash
-git clone https://github.com/xr843/Master-skill ~/Master-skill
-cd ~/Master-skill && pip install -r requirements.txt
-# Register skills (symlink to ~/.codex/skills/)
-for d in prebuilt/*/; do ln -sf "$(pwd)/$d" ~/.codex/skills/"$(basename $d)"; done
-ln -sf "$(pwd)" ~/.codex/skills/create-master
+**OpenCode** — Add to `opencode.json`:
+
+```json
+{"plugin": ["master-skill@git+https://github.com/xr843/Master-skill.git"]}
 ```
 
-**OpenClaw**
+**Codex CLI** — See [.codex/INSTALL.md](.codex/INSTALL.md)
 
-```bash
-git clone https://github.com/xr843/Master-skill ~/.openclaw/workspace/skills/create-master
-cd ~/.openclaw/workspace/skills/create-master && pip install -r requirements.txt
-```
-
-**Manual**
-
-```bash
-git clone https://github.com/xr843/Master-skill
-cd Master-skill && pip install -r requirements.txt
-```
+**Gemini CLI** — Auto-discovered via `gemini-extension.json` and `GEMINI.md`.
 
 ### Use a Pre-built Master
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "master-skill",
+  "description": "Chinese Buddhist Master AI teaching personas — 8 prebuilt masters with CBETA-cited doctrinal responses",
+  "version": "0.3.0",
+  "contextFileName": "GEMINI.md"
+}

--- a/hooks/hooks-cursor.json
+++ b/hooks/hooks-cursor.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "./hooks/session-start"
+      }
+    ]
+  }
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -1,0 +1,29 @@
+: ; # Polyglot wrapper — runs as cmd.exe on Windows, bash on Unix
+: ; exec bash "$0" "$@" 2>/dev/null
+: ; exit
+@echo off
+setlocal enabledelayedexpansion
+
+set "HOOK=%~1"
+set "HOOK_DIR=%~dp0"
+
+:: Try common Git for Windows bash locations
+for %%B in (
+    "C:\Program Files\Git\bin\bash.exe"
+    "C:\Program Files (x86)\Git\bin\bash.exe"
+    "%LOCALAPPDATA%\Programs\Git\bin\bash.exe"
+) do (
+    if exist %%B (
+        %%B "%HOOK_DIR%%HOOK%" %2 %3 %4 %5
+        exit /b %ERRORLEVEL%
+    )
+)
+
+:: Fallback: try bash from PATH
+where bash >nul 2>&1 && (
+    bash "%HOOK_DIR%%HOOK%" %2 %3 %4 %5
+    exit /b %ERRORLEVEL%
+)
+
+:: No bash found — exit silently
+exit /b 0

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Master-skill session-start hook
+# Injects available masters list into conversation context on session start.
+# Compatible with Claude Code, Cursor, and Copilot CLI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Build masters list from prebuilt/ directory
+MASTERS_LIST=""
+for dir in "$PLUGIN_ROOT"/prebuilt/*/; do
+    [ -d "$dir" ] || continue
+    name=$(basename "$dir")
+    [ "$name" = "compare" ] && continue
+    skill_file="$dir/SKILL.md"
+    if [ -f "$skill_file" ]; then
+        # Extract lineage from frontmatter
+        lineage=$(grep '^lineage:' "$skill_file" 2>/dev/null | head -1 | sed 's/^lineage: *//' || echo "")
+        if [ -n "$lineage" ]; then
+            MASTERS_LIST="${MASTERS_LIST}  /${name} — ${lineage}\n"
+        fi
+    fi
+done
+
+# Build the context message
+CONTEXT="Master-skill plugin loaded. Available Buddhist masters:
+${MASTERS_LIST}  /compare-masters — multi-tradition comparison
+  /create-master — generate new master from FoJin knowledge graph
+
+All doctrinal responses include CBETA citations linked to fojin.app."
+
+# Escape for JSON embedding
+CONTEXT_ESCAPED=$(echo "$CONTEXT" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" 2>/dev/null || echo "\"$CONTEXT\"")
+
+# Platform detection and output format
+if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+    # Cursor format
+    echo "{\"additional_context\": $CONTEXT_ESCAPED}"
+elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
+    # Claude Code format
+    echo "{\"hookSpecificOutput\": {\"additionalContext\": $CONTEXT_ESCAPED}}"
+else
+    # Copilot CLI / SDK standard format
+    echo "{\"additionalContext\": $CONTEXT_ESCAPED}"
+fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "master-skill",
   "version": "0.3.0",
+  "type": "module",
   "description": "Chinese Buddhist Master AI Skills — RAG-grounded, source-cited, fidelity-tested",
   "bin": {
     "master-skill": "./bin/cli.mjs"
@@ -8,5 +9,5 @@
   "keywords": ["claude-skills", "agent-skills", "buddhism", "ai-persona", "rag", "digital-humanities"],
   "license": "MIT",
   "repository": {"type": "git", "url": "https://github.com/xr843/Master-skill"},
-  "files": ["bin/", "prebuilt/", "scripts/"]
+  "files": ["bin/", "prebuilt/", "scripts/", "hooks/", ".claude-plugin/", ".cursor-plugin/", ".codex/", ".opencode/"]
 }


### PR DESCRIPTION
## Summary

Add plugin configurations and session-start hooks for 5 additional platforms, making Master-skill installable beyond NPX/manual symlinks. Inspired by [obra/superpowers](https://github.com/obra/superpowers) multi-platform architecture.

### New Platform Support

| Platform | Config | Install Method |
|---|---|---|
| **Claude Code** | `.claude-plugin/plugin.json` + `marketplace.json` | Plugin marketplace (soon) / manual |
| **Cursor** | `.cursor-plugin/plugin.json` | Auto-detected on clone |
| **Codex CLI** | `.codex/INSTALL.md` | Symlink setup |
| **OpenCode** | `.opencode/INSTALL.md` | `opencode.json` plugin entry |
| **Gemini CLI** | `gemini-extension.json` + `GEMINI.md` | Auto-discovered |

### Infrastructure

- **SessionStart hook** (`hooks/session-start`): Injects available masters list on session start with platform detection (Claude Code / Cursor / Copilot CLI output formats)
- **Cross-platform wrapper** (`hooks/run-hook.cmd`): cmd.exe + bash polyglot for Windows compatibility
- **Version management** (`.version-bump.json`): Unified version tracking across all 5 platform config files
- **README updates**: Both Chinese and English READMEs updated with multi-platform install instructions

## Test plan

- [x] `hooks/session-start` outputs valid JSON in Claude Code format
- [x] All JSON config files pass `python3 -m json.tool` validation
- [x] Hook correctly lists all 8 masters with lineage info
- [ ] Cursor plugin detection (needs Cursor environment)
- [ ] OpenCode plugin install (needs OpenCode environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)