### PR TITLE
chore(plugin): sync Cursor plugin metadata with Claude plugin

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "master-skill",
   "displayName": "Master Skill",
-  "description": "Chinese Buddhist Master AI teaching personas — 8 prebuilt masters with CBETA-cited doctrinal responses",
+  "description": "Chinese Buddhist Master AI teaching personas — 8 prebuilt masters with CBETA-cited doctrinal responses, RAG-grounded in FoJin knowledge graph",
   "version": "0.3.0",
   "author": {
     "name": "xr843",
@@ -12,9 +12,12 @@
   "license": "MIT",
   "keywords": [
     "buddhism",
+    "chinese-buddhism",
     "ai-persona",
     "digital-humanities",
     "rag",
+    "cbeta",
+    "fojin",
     "agent-skills"
   ],
   "skills": "./prebuilt/",


### PR DESCRIPTION
## Summary

`.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` had drifted — the Cursor manifest was missing the "RAG-grounded in FoJin knowledge graph" tail in its description, and its `keywords` array had only 5 entries versus 8 in the Claude manifest. Marketplace search and discovery text was diverging between the two platforms.

This PR brings the two manifests into lockstep:

- **description**: Cursor now reads "Chinese Buddhist Master AI teaching personas — 8 prebuilt masters with CBETA-cited doctrinal responses, **RAG-grounded in FoJin knowledge graph**" (matches Claude)
- **keywords**: adds `chinese-buddhism`, `cbeta`, `fojin` to the Cursor manifest so both platforms expose the same 8 keywords

No behavioral change — manifest metadata only. Both platforms still resolve `./prebuilt/` and their respective hook files exactly as before.

## Test plan

- [x] `git diff` shows only the two intended fields changing
- [x] Both JSON files are still valid JSON
- [x] Version fields untouched (no version bump needed)
- [ ] CI validate-and-test.yml passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)