### PR TITLE
fix(ci): use context.repo.repo in verify-links workflow

### DIFF
--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -45,7 +45,7 @@ jobs:
 
             await github.rest.issues.create({
               owner: context.repo.owner,
-              repo: context.repo.name,
+              repo: context.repo.repo,
               title: `[Weekly] FoJin links need update — ${updates} URLs, ${failed} missing`,
               body: `Automated weekly link verification found changes.\n\n` +
                     `- **URL replacements needed:** ${updates}\n` +


### PR DESCRIPTION
## Summary
- `context.repo` object exposes `{owner, repo}`, not `{owner, name}`
- The typo caused POSTs to `repos/xr843//issues` (empty repo, double slash), failing with 404
- Weekly Verify FoJin Links has been silently failing since introduction

## Test plan
- [ ] Trigger workflow_dispatch after merge to confirm issue creation works