### PR TITLE
docs: add npm publish badges + global-install instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 ## [Unreleased]
 
 ### Added
+- npm publish: `master-skill` package live on registry — `npm install -g master-skill` or `npx master-skill` now serves all three published versions (0.4.0 / 0.5.0 / 0.6.0). README badges added for npm version + monthly downloads.
 - `ETHICS.md` — AI transparency, copyright tier (A/B/C/D), religious boundary, dual-track content license, takedown channel.
 - `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` — community infrastructure.
 - `.github/ISSUE_TEMPLATE/` — bug report, feature request, new-master proposal, boundary-violation.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 </p>
 
 <p align="center">
+  <a href="https://www.npmjs.com/package/master-skill"><img src="https://img.shields.io/npm/v/master-skill.svg?label=npm&color=cb3837" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/master-skill"><img src="https://img.shields.io/npm/dm/master-skill.svg?color=cb3837" alt="npm downloads"></a>
   <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   <img src="https://img.shields.io/badge/Python-3.9+-green.svg" alt="Python 3.9+">
   <img src="https://img.shields.io/badge/Claude%20Code-Skill-purple.svg" alt="Claude Code Skill">
@@ -124,7 +126,7 @@
 
 ### 安装
 
-**NPX 一键安装（推荐）**
+**NPX 一键安装（推荐，无需常驻）**
 
 ```bash
 # 安装指定祖师
@@ -135,6 +137,15 @@ npx master-skill install --all
 
 # 查看可用祖师
 npx master-skill list
+```
+
+**全局安装（频繁使用 / 离线场景）**
+
+```bash
+npm install -g master-skill            # 一次性装到 $PATH
+master-skill install master-zhiyi      # 之后省掉 npx，直接调
+master-skill list
+npm update -g master-skill             # 升到下一个 minor / patch
 ```
 
 **Claude Code（插件方式）**

--- a/README_EN.md
+++ b/README_EN.md
@@ -9,6 +9,8 @@
 </p>
 
 <p align="center">
+  <a href="https://www.npmjs.com/package/master-skill"><img src="https://img.shields.io/npm/v/master-skill.svg?label=npm&color=cb3837" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/master-skill"><img src="https://img.shields.io/npm/dm/master-skill.svg?color=cb3837" alt="npm downloads"></a>
   <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
   <img src="https://img.shields.io/badge/Python-3.9+-green.svg" alt="Python 3.9+">
   <img src="https://img.shields.io/badge/Claude%20Code-Skill-purple.svg" alt="Claude Code Skill">
@@ -125,11 +127,20 @@ This project is built out of respect for Buddhist traditions. All content is gen
 
 ### Installation
 
-**NPX (recommended)**
+**NPX (recommended, no global state)**
 
 ```bash
 npx master-skill install --all    # Install all 15 masters
 npx master-skill list             # List available masters
+```
+
+**Global install (frequent use / offline-friendly)**
+
+```bash
+npm install -g master-skill            # Adds the binary to $PATH
+master-skill install master-zhiyi      # No more npx prefix
+master-skill list
+npm update -g master-skill             # Pull next minor / patch
 ```
 
 **Claude Code**


### PR DESCRIPTION
## Summary

Surface the npm registry milestone in the README now that v0.4.0 / v0.5.0 / v0.6.0 are all live at https://www.npmjs.com/package/master-skill.

## Changes

- **README.md / README_EN.md**: add npm version + monthly-downloads shields linking to the package page (top of the badges row)
- **README.md / README_EN.md**: add a "全局安装 / Global install" snippet alongside the existing NPX recipe — covers users who want to skip the `npx` prefix or work offline (`npm install -g master-skill`, `master-skill list`, `npm update -g master-skill`)
- **CHANGELOG.md**: new Unreleased entry noting the registry publish

No code changes, no behavior changes — purely docs / discoverability.

## Test plan

- [ ] Render badges on GitHub PR diff preview
- [ ] Click through both badges → reach the npm package page
- [ ] After merge: `npm install -g master-skill && master-skill list` works on a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)