### PR TITLE
ci(fidelity): weekly full-suite sweep + fix unreachable manual job

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -13,6 +13,12 @@ on:
       - 'scripts/**'
       - 'prompts/**'
       - 'tools/**'
+  workflow_dispatch:
+  schedule:
+    # Weekly full fidelity sweep — Mondays 04:00 UTC. Per-PR CI only runs a
+    # 1-fixture smoke; this is the only run that grades all 160+ fixtures and
+    # catches regressions the smoke rotation would take 14 weeks to surface.
+    - cron: '0 4 * * 1'
 
 jobs:
   validate:
@@ -111,9 +117,9 @@ jobs:
           if-no-files-found: ignore
 
   fidelity-full:
-    name: Fidelity tests — full suite (manual only)
+    name: Fidelity tests — full suite (weekly + manual)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: validate
     steps:
       - uses: actions/checkout@v4
@@ -129,10 +135,18 @@ jobs:
       - name: Run fidelity tests
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: python scripts/test-fidelity.py --all --json > fidelity-results.json
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::warning::ANTHROPIC_API_KEY not configured — full fidelity sweep is advisory (structural validation in the validate job still gates)."
+            echo '{"skipped": true, "reason": "no_api_key"}' > fidelity-results.json
+            exit 0
+          fi
+          python scripts/test-fidelity.py --all --json > fidelity-results.json
 
       - name: Upload results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: fidelity-results
           path: fidelity-results.json
+          if-no-files-found: ignore

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -7,12 +7,14 @@ on:
       - 'scripts/**'
       - 'prompts/**'
       - 'tools/**'
+      - '.github/workflows/validate-and-test.yml'
   pull_request:
     paths:
       - 'prebuilt/**'
       - 'scripts/**'
       - 'prompts/**'
       - 'tools/**'
+      - '.github/workflows/validate-and-test.yml'
   workflow_dispatch:
   schedule:
     # Weekly full fidelity sweep — Mondays 04:00 UTC. Per-PR CI only runs a


### PR DESCRIPTION
## Problem

Per-PR CI only runs a **1-fixture fidelity smoke**. The full 160+-fixture suite (`fidelity-full`) was gated `if: github.event_name == 'workflow_dispatch'` — but **`workflow_dispatch` was never declared in `on:`**, so the job has been unreachable since it was added. The smoke's day-of-year master rotation takes ~14 weeks to cover every master once, and no run has ever graded all fixtures.

## Changes

- **Declare `workflow_dispatch:`** in `on:` — fixes the dead manual job.
- **Add `schedule:` cron** — Mondays 04:00 UTC weekly full sweep.
- `fidelity-full` now runs on `schedule` + `workflow_dispatch`.
- **Advisory no-key guard**: `fidelity-full` now uses the same pattern as `fidelity-smoke` — if `ANTHROPIC_API_KEY` is unset, it warns and exits 0 instead of hard-failing every week. Structural validation (`validate.py` / `validate-fidelity.py`) still gates unconditionally.
- Artifact upload hardened with `if: always()` + `if-no-files-found: ignore`.

## Note for the maintainer

`ANTHROPIC_API_KEY` is **not currently configured** as a repo secret (only `NPM_TOKEN` exists), so the weekly sweep — and the existing per-PR smoke — run in advisory mode and do not actually invoke the LLM grader. This PR wires the scaffolding so weekly LLM grading begins the moment the key is added. Adding the key is a separate cost decision (full sweep ≈ 160 fixtures/week).

YAML verified to parse; no behavior change for `push` / `pull_request` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)