### PR TITLE
docs: fix '15 masters' in plugin manifests + stale fidelity-count claim

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "master-skill",
-  "description": "Buddhist Master AI Skills — 15 historical masters across 汉传/藏传/南传 with source-cited teachings",
+  "description": "Buddhist Master AI Skills — 14 historical masters across 汉传/藏传/南传 plus a compare meta-skill, with source-cited teachings",
   "owner": {
     "name": "xr843",
     "email": "xr843@users.noreply.github.com"
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "master-skill",
-      "description": "Buddhist Master AI teaching personas — 15 prebuilt masters across 汉传/藏传/南传 invokable via /master-<slug> slash commands, with source-cited doctrinal responses (CBETA / BDRC / SuttaCentral / PTS Vism), RAG-grounded in FoJin knowledge graph",
+      "description": "Buddhist Master AI teaching personas — 14 prebuilt masters across 汉传/藏传/南传 plus a compare-masters meta-skill, invokable via /master-<slug> slash commands, with source-cited doctrinal responses (CBETA / BDRC / SuttaCentral / PTS Vism), RAG-grounded in FoJin knowledge graph",
       "version": "0.6.0",
       "source": "./",
       "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "master-skill",
-  "description": "Buddhist Master AI teaching personas — 15 prebuilt masters across 汉传/藏传/南传 invokable via /master-<slug> slash commands, with source-cited doctrinal responses (CBETA / BDRC / SuttaCentral / PTS Vism), RAG-grounded in FoJin knowledge graph",
+  "description": "Buddhist Master AI teaching personas — 14 prebuilt masters across 汉传/藏传/南传 plus a compare-masters meta-skill, invokable via /master-<slug> slash commands, with source-cited doctrinal responses (CBETA / BDRC / SuttaCentral / PTS Vism), RAG-grounded in FoJin knowledge graph",
   "version": "0.6.0",
   "author": {
     "name": "xr843",

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@
 - **渐进式披露**：SKILL.md 以决策树 + Quick Ref 为主，`references/`、`sources/` 按需加载，Context 随查随取
 - **HARD-GATE 铁律**：`/create-master` 与预置法师内置红线——无 CBETA 引证的教义断言不得写入、不得捏造经号、不得为虚构人物建角色
 - **二阶段独立审查**：生成管线在写入前强制经过"教义准确性 → 风格一致性"两轮独立审查，FAIL 自动修复最多 2 轮
-- **自动化保真度测试**：每位祖师 `tests/fidelity.jsonl` 5 条 Q&A，验证引用和关键词覆盖；CI 在每次推送时 dry-run 验证
+- **自动化保真度测试**：每位祖师 `tests/fidelity.jsonl` 10+ 条 Q&A（`compare-masters` 元技能 18 条），验证引用和关键词覆盖；CI 在每次推送时 dry-run 验证
 - **多平台统一插件**：Claude Code、Cursor、Codex CLI、OpenCode、Gemini CLI 共用一份 `prebuilt/`，session-start hook 跨平台注入法师列表
 - **NPX 一键安装**：`npx master-skill install master-zhiyi` 直接部署到 Claude Code
 - **离线工具链**：`scripts/cite.py`（CBETA 引用查询）、`scripts/query.py`（离线语义检索）、`scripts/validate.py`（frontmatter linter）

--- a/README_EN.md
+++ b/README_EN.md
@@ -142,7 +142,7 @@ This project is built out of respect for Buddhist traditions. All content is gen
 - **Progressive disclosure**: SKILL.md is a decision tree + quick reference; `references/` and `sources/` are loaded on demand to keep context lean
 - **HARD-GATE discipline**: Both `/create-master` and every prebuilt master embed hard rules — no unverified CBETA ID, no uncited doctrinal claim, no fictional personas
 - **Two-stage independent review**: The generation pipeline forces a "doctrinal accuracy → voice consistency" review before write; FAIL triggers up to 2 rounds of automatic repair
-- **Automated fidelity tests**: Each master's `tests/fidelity.jsonl` holds 5+ Q&A samples validating citations and keyword coverage; CI runs a dry-run on every push
+- **Automated fidelity tests**: Each master's `tests/fidelity.jsonl` holds 10+ Q&A samples (the `compare-masters` meta-skill holds 18) validating citations and keyword coverage; CI runs a dry-run on every push
 - **Unified multi-platform plugin**: Claude Code, Cursor, Codex CLI, OpenCode, and Gemini CLI share one `prebuilt/` tree, with a session-start hook injecting the master list on every platform
 - **NPX one-shot install**: `npx master-skill install master-zhiyi` drops skills straight into Claude Code
 - **Offline toolchain**: `scripts/cite.py` (CBETA lookup), `scripts/query.py` (offline semantic search), `scripts/validate.py` (frontmatter linter)


### PR DESCRIPTION
Two accuracy fixes found in a repo audit. Docs-only, zero risk.

## 1. Plugin manifests said "15 masters"

`.claude-plugin/marketplace.json` (×2) and `.claude-plugin/plugin.json` (×1) described the project as **"15 masters"**. It is **14 masters + 1 `compare-masters` meta-skill** — `prebuilt/` has 15 directories, but `compare` is not a master. Every other surface (README ×multiple, `package.json`) already says 14. Manifests corrected to "14 masters + a compare-masters meta-skill".

## 2. README feature list undersold the fidelity suite

`README.md` / `README_EN.md` feature list claimed each master holds **"5 / 5+ Q&A"** fidelity cases. Masters now ship **10-13 cases** each, and `compare-masters` holds **18** (after #24). Updated to "10+ Q&A (compare-masters: 18)".

The contributor-facing "at least 5" guidance in README/CONTRIBUTING is the validator's hard floor (`< 5` → error) and is intentionally left unchanged.

JSON manifests verified to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)