### PR TITLE
ci: run required checks on every PR (drop pull_request paths filter)

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -8,13 +8,13 @@ on:
       - 'prompts/**'
       - 'tools/**'
       - '.github/workflows/validate-and-test.yml'
+  # No paths: filter on pull_request — the "Validate" and "Fidelity smoke"
+  # jobs are branch-protection-required checks, so they must run on EVERY
+  # PR. A paths filter would skip them on docs/config-only PRs, leaving the
+  # required checks permanently pending and the PR unmergeable without an
+  # admin override. The validate job is pure structural validation (~9s, no
+  # API calls); running it on every PR is cheap.
   pull_request:
-    paths:
-      - 'prebuilt/**'
-      - 'scripts/**'
-      - 'prompts/**'
-      - 'tools/**'
-      - '.github/workflows/validate-and-test.yml'
   workflow_dispatch:
   schedule:
     # Weekly full fidelity sweep — Mondays 04:00 UTC. Per-PR CI only runs a


### PR DESCRIPTION
## Problem

`Validate SKILL.md & fidelity structure` and `Fidelity smoke` are **branch-protection-required** checks on `main`. But the `pull_request` trigger in `validate-and-test.yml` had a `paths:` filter (`prebuilt/scripts/prompts/tools` + the workflow file).

Any PR that doesn't touch those paths — i.e. **every docs-only or `.claude-plugin/` config PR** — never triggers the jobs, so the required checks sit permanently `pending` and the PR is `BLOCKED` with no way to satisfy them except an admin override.

This already hit **#25** (fixed reactively by adding the workflow file to the filter) and **#26** (had to be admin-merged).

## Fix

Drop the `paths:` filter from `pull_request` entirely, so both required checks run on **every** PR.

- The `validate` job is pure structural validation — ~9s, no API calls.
- `fidelity-smoke` is a single advisory fixture (no-ops without `ANTHROPIC_API_KEY`).

Running them unconditionally is cheap and makes branch protection actually work for non-code PRs. The `push` trigger keeps its `paths:` filter — re-running validation on docs-only commits to `main` post-merge adds nothing.

YAML verified to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)