### PR TITLE
chore(v0.8): security hardening — SHA pin actions + npm provenance + OIDC + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+
+# Dependabot keeps our supply chain fresh:
+#   - github-actions: bumps the SHA-pinned actions in .github/workflows/.
+#     Dependabot writes the new SHA + a comment with the new version.
+#   - npm:            bumps the (currently empty) package.json deps + the
+#     globally-pinned promptfoo@<ver> in persona-fidelity.yml.
+#   - pip:            bumps requirements.txt (Python validators).
+#
+# All updates open weekly Monday PRs with the `dependencies` label plus an
+# ecosystem-specific label so the maintainer can filter quickly. Major-
+# version bumps are NOT auto-merged — they require explicit review.
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "pip"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,28 @@
 name: Publish to npm
 
 # Triggered on release tags (v0.3.0, v0.3.1, v1.0.0, ...) or manually.
-# First-time publish requires: Settings → Secrets → Actions → NPM_TOKEN
-# Generate at https://www.npmjs.com/settings/~/tokens (type: Automation / Granular).
+#
+# Supply-chain hardening (v0.8):
+#   - All `uses:` are pinned to a full commit SHA + version comment.
+#     Bumps are PR'd by Dependabot (see .github/dependabot.yml).
+#   - npm publish uses --provenance and OIDC Trusted Publishing.
+#     No NPM_TOKEN secret is needed (or trusted) — the GitHub OIDC
+#     id-token is exchanged at npmjs.com for short-lived publish creds.
+#
+# First-time / re-configuration setup (one-time, by repo admin):
+#   1. npmjs.com → Package "master-skill" → Settings → Trusted Publisher
+#   2. Add Trusted Publisher:
+#        Publisher: GitHub Actions
+#        Owner:     xr843
+#        Repository: Master-skill
+#        Workflow:  npm-publish.yml
+#        Environment: npm   (matches `environment.name` below)
+#   3. Confirm. From this point on, NPM_TOKEN can be deleted from
+#      repo Settings → Secrets → Actions (it is no longer used).
+#
+# Until Trusted Publisher is configured, the `Publish` step will fail
+# with a clear 401 from npm — that is the expected first-run failure;
+# fix it by completing the setup above, then re-run the release.
 
 on:
   release:
@@ -18,7 +38,7 @@ on:
 
 permissions:
   contents: read
-  # id-token needed if we move to npm provenance / trusted publishing later
+  # Required for npm provenance + OIDC Trusted Publishing.
   id-token: write
 
 jobs:
@@ -28,10 +48,10 @@ jobs:
       name: npm
       url: https://www.npmjs.com/package/master-skill
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
@@ -60,11 +80,7 @@ jobs:
 
       - name: Publish
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry-run == 'false')
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN secret not configured. Add it at Settings → Secrets → Actions."
-            exit 1
-          fi
-          npm publish --access public --provenance
+        # No NODE_AUTH_TOKEN / NPM_TOKEN env — authentication is via
+        # OIDC Trusted Publisher. setup-node above wrote a .npmrc that
+        # `npm publish --provenance` will use for the OIDC token exchange.
+        run: npm publish --access public --provenance

--- a/.github/workflows/persona-fidelity.yml
+++ b/.github/workflows/persona-fidelity.yml
@@ -56,8 +56,11 @@ jobs:
         # llm-rubric presence, contains-any whitelist, shared.yaml sync.
         run: python scripts/validate-promptfoo-configs.py
 
-      - name: Install promptfoo CLI
-        run: npm install -g promptfoo
+      - name: Install promptfoo CLI (pinned)
+        # Pin to the previous-week stable to avoid landing on a brand-new
+        # release that may regress YAML parsing. Bumped by Dependabot npm
+        # ecosystem (see .github/dependabot.yml).
+        run: npm install -g promptfoo@0.121.14
 
       - name: Validate promptfoo YAML schema (always)
         # Falls back gracefully if `promptfoo validate` is unavailable in this

--- a/.github/workflows/persona-fidelity.yml
+++ b/.github/workflows/persona-fidelity.yml
@@ -41,10 +41,10 @@ jobs:
     name: Persona-fidelity schema + advisory eval
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload eval results
         if: steps.key.outputs.advisory == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: persona-fidelity-results-${{ github.run_id }}
           path: .promptfoo-results/

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -27,10 +27,10 @@ jobs:
     name: Validate SKILL.md & fidelity structure
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -63,12 +63,12 @@ jobs:
     # with ~10k-token system prompt → under $0.05/PR. Forks have no secret
     # access — treat missing secret as advisory pass so external PRs can land.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload smoke results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: fidelity-smoke-${{ github.run_id }}
           path: fidelity-smoke.json
@@ -133,10 +133,10 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: validate
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: fidelity-results
           path: fidelity-results.json

--- a/.github/workflows/verify-links.yml
+++ b/.github/workflows/verify-links.yml
@@ -14,10 +14,10 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.11'
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create issue if links need updating
         if: steps.verify.outputs.updates != '0' || steps.verify.outputs.failed != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const fs = require('fs');

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 
 ## [Unreleased]
 
+### Security — v0.8 supply chain hardening
+- **SHA-pinned all GitHub Actions** across the four workflows (`npm-publish.yml`, `persona-fidelity.yml`, `validate-and-test.yml`, `verify-links.yml`). Every `uses:` now references a full commit SHA with a version comment, e.g.
+  ```yaml
+  - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+  ```
+  This neutralises mutable-tag attacks where a compromised maintainer could re-point `v4` at a malicious commit.
+- **Migrated npm publish to OIDC Trusted Publishing + provenance.** Removed the `NODE_AUTH_TOKEN`/`NPM_TOKEN` env wiring; `npm publish --access public --provenance` now relies on the GitHub Actions OIDC `id-token` to obtain short-lived publish credentials from npmjs.com. Consumers can verify the published tarball's build origin via `npm audit signatures`.
+- **Pinned `promptfoo` CLI version** in `persona-fidelity.yml` (`npm install -g promptfoo@0.121.14`). Dependabot bumps this on the weekly cadence — no more silent CLI surprises.
+- **Added `.github/dependabot.yml`** covering three ecosystems (`github-actions`, `npm`, `pip`) with weekly Monday PRs and `dependencies` + ecosystem labels.
+- **`SECURITY.md`**: bumped supported-version table to `0.7.x` + appended a "供应链安全" section documenting the hardening posture.
+- **Main branch protection**: required status checks expanded to include `Persona-fidelity schema + advisory eval` alongside the existing `Validate SKILL.md & fidelity structure` and `Fidelity smoke (1 master × 1 fixture)`. Applied via `gh api` after merge.
+- **Docs**: README badge row gained a one-liner pointing at SECURITY.md; CONTRIBUTING.md gained a "§ 7 依赖 PR" section explaining the Dependabot review workflow + SHA-cross-check.
+
 ### Added — v0.8 promptfoo persona-fidelity eval (RAW/SPE/CUS)
 - `tests/persona/` — new evaluation layer that consumes the v0.8 `signature_phrases` / `style` schema and grades each master persona on three dimensions borrowed from the RoleLLM / RoleBench framework:
   - **RAW** — raw instruction-following + ETHICS gates (modern politics / medical / legal / tantric overreach refusals)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,6 +264,33 @@ v0.8 在 `meta.json` 引入 `lore_triggers`，让 runtime 在用户提问命中 
 
 ---
 
+## § 7 依赖 PR（Dependabot 自动开）
+
+本仓库自 v0.8 起开启 [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates)，每周一自动开三类依赖升级 PR：
+
+| 生态 | 监控目标 |
+|------|---------|
+| `github-actions` | `.github/workflows/*.yml` 中所有 SHA-pin 的 actions |
+| `npm` | `package.json` 依赖 + workflow 中 `npm install -g promptfoo@<ver>` |
+| `pip` | `requirements.txt`（validate / fidelity 工具链） |
+
+**maintainer review 流程**（也欢迎贡献者帮忙跑）：
+
+1. **CI 必须全绿**——所有 required status checks 是依赖更新最可靠的回归信号。
+2. **SHA 真实性核对**（仅 github-actions PR）：
+   ```bash
+   gh api repos/actions/<name>/git/refs/tags/<new-version> --jq '.object.sha'
+   ```
+   与 Dependabot PR 里写的 SHA 比对，一致才合并。
+3. **major bump 不可自动合并**：major 版本通常含 breaking change，必须人工读 release note + 跑 fidelity smoke 确认行为不变。
+4. **minor / patch**：CI 绿即可合并，合并方式与本仓库其它 PR 一致——`gh pr merge --merge`（保留 commit 历史）。
+
+如需手动触发一次扫描：仓库 Settings → Code security and analysis → Dependabot → "Check for updates"。
+
+> 报告 Dependabot 误判 / 漏报：开普通 issue，标签选 `dependencies`。
+
+---
+
 ## 问题？
 
 - 技术问题 → [Bug Report](https://github.com/xr843/Master-skill/issues/new?template=bug_report.yml)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 </p>
 
 <p align="center">
+  <sub><em>Secured by SHA-pinned GitHub Actions · npm provenance · OIDC Trusted Publishing — see <a href="SECURITY.md">SECURITY.md</a>.</em></sub>
+</p>
+
+<p align="center">
   翻开《瑜伽师地论》百卷，不知从何读起？<br>
   想学禅宗，不知应当亲近哪位祖师？<br>
   读白话译注总隔一层，又难以直入文言？<br>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ Master-skill 以 `main` 为持续发布分支。我们仅对以下版本承诺 s
 | 版本 | 状态 |
 |------|------|
 | `main` (latest) | ✅ 持续修复 |
-| `0.3.x` | ✅ 持续修复 |
-| `< 0.3.0` | ❌ 不再维护 |
+| `0.7.x` | ✅ 持续修复 |
+| `< 0.7.0` | ❌ 不再维护 |
 
 ---
 
@@ -99,6 +99,20 @@ Master-skill 作为 AgentSkill 插件 + NPX CLI，主要关注以下安全面：
 - 负责任披露：[GitHub Security Advisory Policy](https://docs.github.com/en/code-security/security-advisories)
 - 内容安全边界：[`ETHICS.md`](ETHICS.md) §3
 - 社区安全：[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
+---
+
+## 供应链安全（Supply Chain Security）
+
+本仓库已实施以下供应链加固措施（v0.8 起）：
+
+- **GitHub Actions 全部 SHA pin**：所有 `uses:` 引用都锁定到完整 commit SHA + 版本注释，防止 tag 被重打（mutable tag attack）。Dependabot 每周一自动开 PR 升级。
+- **npm 发布使用 OIDC Trusted Publishing**：发版无需长期 `NPM_TOKEN` secret，改用 GitHub Actions OIDC id-token 在 npmjs.com 换取短期发布凭据。
+- **npm provenance attestation**：每次 `npm publish` 附带 sigstore 透明日志可验证的构建溯源，安装方可通过 `npm install --foreground-scripts master-skill` + `npm audit signatures` 验证。
+- **Dependabot 三生态**：`github-actions` / `npm` / `pip` 每周一统一开 PR；major bump 必须人工 review。
+- **主分支保护**：required status checks 包含 `Validate SKILL.md & fidelity structure`、`Fidelity smoke`、`Persona-fidelity schema + advisory eval`；禁止 force push 与分支删除。
+
+如需复核或质疑某条措施，欢迎在 Discussion 提出。
 
 ---
 


### PR DESCRIPTION
## Summary

v0.8 发版前的供应链安全加固。**纯基础设施/CI/文档改动，不动业务代码、不动 14 master meta.json、不发新版本。**

- **SHA-pin all GitHub Actions** in 4 workflows — neutralises mutable-tag attacks (e.g. tj-actions/changed-files style supply-chain takeovers).
- **Migrate `npm publish` to OIDC Trusted Publishing + provenance** — no long-lived `NPM_TOKEN` secret needed; consumers can verify build origin via `npm audit signatures`.
- **Pin `promptfoo` CLI to 0.121.14** — previous-week stable, no more silent CLI surprises in CI.
- **Add `.github/dependabot.yml`** covering `github-actions` / `npm` / `pip` weekly on Mondays.
- **Refresh `SECURITY.md`** — supported-version table bumped to `0.7.x`, appended a "供应链安全" section documenting every measure.
- **Tighten main branch protection** (via `gh api` after merge — see Required follow-up) — add `Persona-fidelity schema + advisory eval` to required status checks.

## Why

| 改动 | 对应风险 |
|------|---------|
| SHA pin actions | Tag mutability — `@v4` 可被重打到恶意 commit；2024-25 多起供应链事件（tj-actions 等）实证。 |
| OIDC Trusted Publishing | 长期 NPM_TOKEN 泄露面（已知该项目曾发生 token revoke）；OIDC 提供短期凭据 + 可审计。 |
| npm `--provenance` | 安装方无法验证 tarball 来源真实性；attestation 走 sigstore 透明日志。 |
| promptfoo pin | 上游意外回归（如 YAML 解析）打挂 PR CI；保持周节奏可控。 |
| Dependabot 3 ecosystems | 加固后必须有自动更新机制，否则 SHA 会逐渐过时。 |
| 主分支保护扩 | `Persona-fidelity` PR #33 加的，但未纳入 required，绕过它就能 merge persona schema breakage。 |

## Required follow-up (manual, repo admin — 我执行不了，需要你在浏览器走一遍)

PR merged 后我会立刻：
1. **执行 `gh api -X PUT` 更新主分支保护** — 加入 `Persona-fidelity schema + advisory eval` 到 required contexts。
2. 把 before/after JSON 作为评论贴到本 PR。

**你需要手动做的（一次性，仅 npm publish 用到）**：

1. 访问 https://www.npmjs.com/package/master-skill/access
2. 点击 **"Settings"** → **"Trusted Publisher"** → **"Add trusted publisher"**
3. 填表：
   - Publisher: `GitHub Actions`
   - Owner: `xr843`
   - Repository: `Master-skill`
   - Workflow filename: `npm-publish.yml`
   - Environment name: `npm`
4. 保存。
5. （可选但建议）到 GitHub 仓库 Settings → Secrets and variables → Actions，**删除已 revoke 的 `NPM_TOKEN` 残留** — 走 OIDC 后再无意义。

在 Trusted Publisher 配置好之前，任何 `release` 触发的 `npm publish` 会 401 失败——这是预期的首次失败信号，不是 regression。

## Test plan

- [x] 本地 `npm run validate` 绿（17 skills pass）
- [x] 本地 `npm run validate:fidelity` 绿（17 masters validated）
- [x] 本地 `pytest scripts/tests/ -v` — 73 passed
- [x] 4 个 workflow YAML 全部 `yaml.safe_load` 通过
- [x] 5 个 SHA 全部用 `gh api repos/<repo>/git/refs/tags/<ver>` 二次校验真实性
- [x] `promptfoo@0.121.14` 在 npm registry 实存
- [ ] PR CI 全绿（自测 — 本 PR 改了 workflow，CI 会用新 SHA 跑）
- [ ] merged 后 `gh api -X PUT` 应用 branch protection 成功

## Out of scope (按 maintainer 指示明确不动)

- 不动 14 master meta.json / SKILL.md 业务内容
- 不动 hooks/session-start（PR #35 在改）
- 不改 ETHICS.md
- 不发新 npm 版本 / 不打 tag — 等 v0.8 业务侧完成再统一发