### PR TITLE
fix(ci): npm-publish needs Node 24 (npm >= 11.5.1) for OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -53,7 +53,10 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: "20"
+          # Node >= 24 ships npm >= 11.5.1, the minimum for OIDC Trusted
+          # Publishing token exchange. Node 20's npm 10.x silently skips
+          # the exchange and the unauthenticated PUT fails with E404.
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Verify CLI is executable


### PR DESCRIPTION
## Summary

v0.8.0 npm publish failed twice with E404 even after the Trusted Publisher was configured on npmjs.com. Root cause: the workflow pins `node-version: "20"`, whose npm 10.x predates OIDC Trusted Publishing (added in npm 11.5.1). The CLI never attempts the token exchange, so the PUT is unauthenticated → registry replies 404. Provenance signing succeeded because the sigstore path doesn't depend on it — which is what made the log misleading.

Node 24 ships npm 11.5.1+.

## After merge

Publish v0.8.0 from main via the existing dispatch path (the release-tag run can't pick up this fix):

```
gh workflow run npm-publish.yml -f dry-run=false
```

The "Verify version matches tag" guard is release-event-only by design; main's package.json is already 0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)