### PR TITLE
fix(cli): Windows path resolution, stale-file cleanup, exit codes, --version + test suite

### DIFF
--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -7,6 +7,10 @@ on:
       - 'scripts/**'
       - 'prompts/**'
       - 'tools/**'
+      - 'bin/**'
+      - 'tests/**'
+      - 'hooks/**'
+      - 'package.json'
       - '.github/workflows/validate-and-test.yml'
   # No paths: filter on pull_request — the "Validate" and "Fidelity smoke"
   # jobs are branch-protection-required checks, so they must run on EVERY
@@ -69,9 +73,9 @@ jobs:
         run: node --test tests/cli.test.mjs
 
   # bin/cli.mjs is the one piece of code every npx user executes, and its
-  # path handling broke silently on Windows before v0.8.1 (URL.pathname gives
-  # "/C:/…"). This job is the regression net: the same node:test suite, on a
-  # native Windows runner with a CRLF-defaulting git.
+  # path handling broke silently on Windows before this fix (URL.pathname
+  # gives "/C:/…"). This job is the regression net: the same node:test suite,
+  # on a native Windows runner with a CRLF-defaulting git.
   cli-windows:
     name: CLI tests (Windows)
     runs-on: windows-latest

--- a/.github/workflows/validate-and-test.yml
+++ b/.github/workflows/validate-and-test.yml
@@ -65,6 +65,26 @@ jobs:
       - name: Dry-run fidelity tests
         run: python scripts/test-fidelity.py --all --dry-run
 
+      - name: Run CLI tests
+        run: node --test tests/cli.test.mjs
+
+  # bin/cli.mjs is the one piece of code every npx user executes, and its
+  # path handling broke silently on Windows before v0.8.1 (URL.pathname gives
+  # "/C:/…"). This job is the regression net: the same node:test suite, on a
+  # native Windows runner with a CRLF-defaulting git.
+  cli-windows:
+    name: CLI tests (Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: "20"
+
+      - name: Run CLI tests
+        run: node --test tests/cli.test.mjs
+
   fidelity-smoke:
     name: Fidelity smoke (1 master × 1 fixture)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 - **Name validation.** Install/uninstall names are restricted to `[A-Za-z0-9_-]`, so a path-traversal typo can never escape `prebuilt/` or `~/.claude/skills/`.
 
 ### Added — CLI test suite + Windows CI
-- `tests/cli.test.mjs` — 12 `node:test` integration tests (zero new dependencies) covering list output, `--version`, short/full-name install, stale-file cleanup on reinstall, partial-failure exit codes, path-traversal rejection, `--all`, and uninstall. Run via `npm run test:cli`; also appended to `npm test`.
+- `tests/cli.test.mjs` — 14 `node:test` integration tests (zero new dependencies) covering list output, `--version`, short/full-name install, stale-file cleanup on reinstall, partial-failure exit codes, install **and uninstall** path-traversal rejection, a deterministic CRLF frontmatter fixture, `--all`, and uninstall. Run via `npm run test:cli`; also appended to `npm test`.
 - CI: new `cli-windows` job runs the same suite on `windows-latest` — the regression net that would have caught the `URL.pathname` bug at introduction.
+- CI: `on.push.paths` now includes `bin/**`, `tests/**`, `hooks/**`, and `package.json` — direct pushes touching only the CLI previously triggered zero CI.
 
 ## [0.8.0] — 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Sections marked **Ethics** track changes to `ETHICS.md`, content licensing, or b
 
 ---
 
+## [Unreleased]
+
+### Fixed — CLI hardening
+- **Windows path resolution.** `bin/cli.mjs` resolved its own location via `new URL(import.meta.url).pathname`, which yields `/C:/…` on Windows — every command saw an empty `prebuilt/` and `npx master-skill list` printed "No prebuilt masters found." on native Windows. Now uses `fileURLToPath`. Frontmatter parsing also accepts CRLF line endings, so descriptions survive a `core.autocrlf` checkout.
+- **Reinstall now clears the destination first.** `install` used to copy over an existing `~/.claude/skills/master-*/` without cleaning it, so files renamed or removed upstream lingered as stale skill content across upgrades.
+- **Non-zero exit codes on failure.** `install`/`uninstall` with unknown names, and `install` with no masters available, now exit 1 instead of reporting success to scripts and CI consumers.
+- **`--version` flag** (reads `package.json`); help text no longer hardcodes a stale "v0.6+".
+- **Name validation.** Install/uninstall names are restricted to `[A-Za-z0-9_-]`, so a path-traversal typo can never escape `prebuilt/` or `~/.claude/skills/`.
+
+### Added — CLI test suite + Windows CI
+- `tests/cli.test.mjs` — 12 `node:test` integration tests (zero new dependencies) covering list output, `--version`, short/full-name install, stale-file cleanup on reinstall, partial-failure exit codes, path-traversal rejection, `--all`, and uninstall. Run via `npm run test:cli`; also appended to `npm test`.
+- CI: new `cli-windows` job runs the same suite on `windows-latest` — the regression net that would have caught the `URL.pathname` bug at introduction.
+
 ## [0.8.0] — 2026-06-12
 
 ### Added — v0.8 content completeness (release prep)

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -211,5 +211,5 @@ if (!cmd || cmd === "--help" || cmd === "-h") {
   }
 } else {
   console.log(`Unknown command: ${cmd}\nRun master-skill --help for usage.`);
-  process.exit(1);
+  process.exitCode = 1;
 }

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -3,15 +3,32 @@
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { fileURLToPath } from "url";
 
-const PREBUILT = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
-  "..",
-  "prebuilt"
-);
+// fileURLToPath (not new URL().pathname) — on Windows the URL pathname is
+// "/C:/…", which fs cannot resolve, so every command saw an empty prebuilt/.
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PREBUILT = path.join(__dirname, "..", "prebuilt");
 const SKILLS_DIR = path.join(os.homedir(), ".claude", "skills");
 
 // --- helpers ---
+
+function pkgVersion() {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8")
+    );
+    return pkg.version || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+// Names feed into path.join + rmSync; reject separators / ".." so a typo
+// like "../foo" can never escape PREBUILT or SKILLS_DIR.
+function isSafeName(name) {
+  return /^[A-Za-z0-9_-]+$/.test(name);
+}
 
 function cpR(src, dest) {
   fs.mkdirSync(dest, { recursive: true });
@@ -24,11 +41,13 @@ function cpR(src, dest) {
 }
 
 function parseFrontmatter(filepath) {
+  // \r?\n: a CRLF checkout (git autocrlf on Windows) must not blank out
+  // every description.
   const text = fs.readFileSync(filepath, "utf8");
-  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!m) return {};
   const fm = {};
-  for (const line of m[1].split("\n")) {
+  for (const line of m[1].split(/\r?\n/)) {
     const idx = line.indexOf(":");
     if (idx > 0 && !line.startsWith(" ") && !line.startsWith("-")) {
       fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
@@ -76,23 +95,42 @@ function resolveMasterDir(input) {
   return candidates.find((p) => fs.existsSync(p)) || null;
 }
 
+// Returns the number of failures so main can set a non-zero exit code —
+// scripted callers must be able to tell a typo from a clean install.
 function cmdInstall(names) {
   fs.mkdirSync(SKILLS_DIR, { recursive: true });
+  let failed = 0;
   for (const name of names) {
+    if (!isSafeName(name)) {
+      console.log(`  ✗ ${name} — invalid name (letters, digits, "-", "_" only)`);
+      failed++;
+      continue;
+    }
     const src = resolveMasterDir(name);
     if (!src) {
       console.log(`  ✗ ${name} — not found in prebuilt/ (tried "${name}" and "master-${name}")`);
+      failed++;
       continue;
     }
     const dirName = path.basename(src);          // master-zhiyi
     const dest = path.join(SKILLS_DIR, dirName);
+    // Clear any previous install first: files renamed or removed upstream
+    // must not linger as stale skill content under ~/.claude/skills/.
+    fs.rmSync(dest, { recursive: true, force: true });
     cpR(src, dest);
     console.log(`  ✓ ${name} → ${dest}`);
   }
+  return failed;
 }
 
 function cmdUninstall(names) {
+  let failed = 0;
   for (const name of names) {
+    if (!isSafeName(name)) {
+      console.log(`  ✗ ${name} — invalid name (letters, digits, "-", "_" only)`);
+      failed++;
+      continue;
+    }
     // Try both prefixed and bare directory names for backward compatibility
     // with any pre-v0.6 installs that may still sit at ~/.claude/skills/<slug>/.
     const candidates = [
@@ -102,22 +140,25 @@ function cmdUninstall(names) {
     const dest = candidates.find((p) => fs.existsSync(p));
     if (!dest) {
       console.log(`  ✗ ${name} — not installed`);
+      failed++;
       continue;
     }
     fs.rmSync(dest, { recursive: true, force: true });
     console.log(`  ✓ ${name} removed (${dest})`);
   }
+  return failed;
 }
 
 function showHelp() {
   console.log(`
-master-skill — Buddhist Master AI Skills installer (v0.6+)
+master-skill v${pkgVersion()} — Buddhist Master AI Skills installer
 
 Usage:
   master-skill install <name...>   Install masters to ~/.claude/skills/
   master-skill install --all       Install all available masters
   master-skill list                List available masters
   master-skill uninstall <name...> Remove installed masters
+  master-skill --version           Print version
   master-skill --help              Show this help
 
 Names accept both short (zhiyi) and full (master-zhiyi) forms.
@@ -139,6 +180,8 @@ const cmd = args[0];
 
 if (!cmd || cmd === "--help" || cmd === "-h") {
   showHelp();
+} else if (cmd === "--version" || cmd === "-v") {
+  console.log(pkgVersion());
 } else if (cmd === "list") {
   cmdList();
 } else if (cmd === "install") {
@@ -147,21 +190,24 @@ if (!cmd || cmd === "--help" || cmd === "-h") {
     const all = availableMasters().map((m) => m.name);
     if (!all.length) {
       console.log("No masters available.");
+      process.exitCode = 1;
     } else {
       console.log(`Installing all ${all.length} masters...\n`);
-      cmdInstall(all);
+      if (cmdInstall(all) > 0) process.exitCode = 1;
     }
   } else if (rest.length === 0) {
     console.log("Usage: master-skill install <name...> | --all");
+    process.exitCode = 1;
   } else {
-    cmdInstall(rest);
+    if (cmdInstall(rest) > 0) process.exitCode = 1;
   }
 } else if (cmd === "uninstall") {
   const rest = args.slice(1);
   if (rest.length === 0) {
     console.log("Usage: master-skill uninstall <name...>");
+    process.exitCode = 1;
   } else {
-    cmdUninstall(rest);
+    if (cmdUninstall(rest) > 0) process.exitCode = 1;
   }
 } else {
   console.log(`Unknown command: ${cmd}\nRun master-skill --help for usage.`);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "validate:lore-content": "python scripts/validate-lore-triggers-content.py",
     "validate:versions": "python scripts/check-manifest-versions.py",
     "test:hook": "bash hooks/tests/test_session_start.sh",
-    "test": "python scripts/validate.py --strict && python scripts/validate-fidelity.py && python scripts/validate-persona-fidelity.py && python scripts/check-manifest-versions.py && python scripts/test-fidelity.py --all --dry-run",
+    "test:cli": "node --test tests/cli.test.mjs",
+    "test": "python scripts/validate.py --strict && python scripts/validate-fidelity.py && python scripts/validate-persona-fidelity.py && python scripts/check-manifest-versions.py && python scripts/test-fidelity.py --all --dry-run && node --test tests/cli.test.mjs",
     "test:smoke": "python scripts/test-fidelity.py --master yinguang --max-tests 1",
     "prepack": "node bin/cli.mjs list"
   },

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -25,7 +25,9 @@ function run(args, env = {}) {
     });
     return { stdout, code: 0 };
   } catch (err) {
-    return { stdout: (err.stdout || "") + (err.stderr || ""), code: err.status };
+    // err.status is null when the child died to a signal — surface -1 so an
+    // assertion failure reads as "crashed", not a confusing null-vs-1 diff.
+    return { stdout: (err.stdout || "") + (err.stderr || ""), code: err.status ?? -1 };
   }
 }
 
@@ -104,6 +106,17 @@ test("install rejects path-traversal names", (t) => {
   assert.ok(!fs.existsSync(path.join(home, ".claude", "escape")));
 });
 
+test("uninstall rejects path-traversal names without touching the filesystem", (t) => {
+  const { home, env } = tmpHome(t);
+  // The victim sits where "../victim" would resolve from ~/.claude/skills/.
+  const victim = path.join(home, ".claude", "victim");
+  fs.mkdirSync(victim, { recursive: true });
+  const { stdout, code } = run(["uninstall", "../victim"], env);
+  assert.equal(code, 1);
+  assert.match(stdout, /invalid name/);
+  assert.ok(fs.existsSync(victim), "victim dir was deleted by traversal");
+});
+
 test("partial failure still installs the valid names but exits non-zero", (t) => {
   const { home, env } = tmpHome(t);
   const { code } = run(["install", "zhiyi", "no-such-master"], env);
@@ -141,4 +154,28 @@ test("install --all installs every prebuilt master", (t) => {
 test("unknown command exits non-zero", () => {
   const { code } = run(["frobnicate"]);
   assert.equal(code, 1);
+});
+
+// Deterministic CRLF coverage: the windows-latest job only exercises CRLF
+// because the repo lacks .gitattributes and the runner defaults autocrlf=true.
+// This test pins the code path on every OS by building a synthetic install
+// tree whose SKILL.md is written with \r\n line endings.
+test("list parses frontmatter from CRLF files", (t) => {
+  const tree = fs.mkdtempSync(path.join(os.tmpdir(), "master-skill-crlf-test-"));
+  t.after(() => fs.rmSync(tree, { recursive: true, force: true }));
+
+  fs.mkdirSync(path.join(tree, "bin"));
+  fs.copyFileSync(CLI, path.join(tree, "bin", "cli.mjs"));
+  fs.writeFileSync(path.join(tree, "package.json"), '{"version": "0.0.0-test"}');
+  const masterDir = path.join(tree, "prebuilt", "master-crlf");
+  fs.mkdirSync(masterDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(masterDir, "SKILL.md"),
+    "---\r\nname: master-crlf\r\ndescription: CRLF survives parsing\r\n---\r\n\r\n# body\r\n"
+  );
+
+  const stdout = execFileSync(process.execPath, [path.join(tree, "bin", "cli.mjs"), "list"], {
+    encoding: "utf8",
+  });
+  assert.match(stdout, /master-crlf\s+CRLF survives parsing/);
 });

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,0 +1,144 @@
+// CLI integration tests — run with: node --test tests/cli.test.mjs
+//
+// Each test spawns bin/cli.mjs as a child process with HOME/USERPROFILE
+// pointed at a temp dir, so installs never touch the real ~/.claude/skills.
+// os.homedir() reads HOME on POSIX and USERPROFILE on Windows; setting both
+// keeps the suite green on every CI runner.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.join(__dirname, "..");
+const CLI = path.join(REPO, "bin", "cli.mjs");
+
+function run(args, env = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI, ...args], {
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+    });
+    return { stdout, code: 0 };
+  } catch (err) {
+    return { stdout: (err.stdout || "") + (err.stderr || ""), code: err.status };
+  }
+}
+
+function tmpHome(t) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "master-skill-cli-test-"));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  return { home, env: { HOME: home, USERPROFILE: home } };
+}
+
+function skillsDir(home) {
+  return path.join(home, ".claude", "skills");
+}
+
+const prebuiltMasters = fs
+  .readdirSync(path.join(REPO, "prebuilt"), { withFileTypes: true })
+  .filter((d) => d.isDirectory() && d.name !== "compare")
+  .map((d) => d.name);
+
+test("list names every prebuilt master with its description", () => {
+  const { stdout, code } = run(["list"]);
+  assert.equal(code, 0);
+  assert.match(stdout, new RegExp(`Available masters \\(${prebuiltMasters.length}\\)`));
+  for (const name of prebuiltMasters) {
+    assert.ok(stdout.includes(name), `missing ${name} in list output`);
+  }
+  // Frontmatter must parse (incl. CRLF checkouts): every listed master has a
+  // non-empty description, so at least one known description string appears.
+  assert.match(stdout, /master-huineng\s+\S/);
+});
+
+test("--version prints the package.json version", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(REPO, "package.json"), "utf8"));
+  const { stdout, code } = run(["--version"]);
+  assert.equal(code, 0);
+  assert.equal(stdout.trim(), pkg.version);
+});
+
+test("help shows the current version, not a hardcoded one", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(REPO, "package.json"), "utf8"));
+  const { stdout, code } = run(["--help"]);
+  assert.equal(code, 0);
+  assert.ok(stdout.includes(`v${pkg.version}`));
+});
+
+test("install accepts short and full names", (t) => {
+  const { home, env } = tmpHome(t);
+  const { code } = run(["install", "zhiyi", "master-fazang"], env);
+  assert.equal(code, 0);
+  assert.ok(fs.existsSync(path.join(skillsDir(home), "master-zhiyi", "SKILL.md")));
+  assert.ok(fs.existsSync(path.join(skillsDir(home), "master-fazang", "SKILL.md")));
+});
+
+test("reinstall clears stale files from a previous version", (t) => {
+  const { home, env } = tmpHome(t);
+  run(["install", "zhiyi"], env);
+  const stale = path.join(skillsDir(home), "master-zhiyi", "sources", "removed-in-new-version.md");
+  fs.writeFileSync(stale, "stale content");
+  const { code } = run(["install", "zhiyi"], env);
+  assert.equal(code, 0);
+  assert.ok(!fs.existsSync(stale), "stale file survived reinstall");
+  assert.ok(fs.existsSync(path.join(skillsDir(home), "master-zhiyi", "SKILL.md")));
+});
+
+test("install of an unknown master exits non-zero", (t) => {
+  const { env } = tmpHome(t);
+  const { stdout, code } = run(["install", "no-such-master"], env);
+  assert.equal(code, 1);
+  assert.match(stdout, /not found/);
+});
+
+test("install rejects path-traversal names", (t) => {
+  const { home, env } = tmpHome(t);
+  const { stdout, code } = run(["install", "../escape"], env);
+  assert.equal(code, 1);
+  assert.match(stdout, /invalid name/);
+  assert.ok(!fs.existsSync(path.join(home, ".claude", "escape")));
+});
+
+test("partial failure still installs the valid names but exits non-zero", (t) => {
+  const { home, env } = tmpHome(t);
+  const { code } = run(["install", "zhiyi", "no-such-master"], env);
+  assert.equal(code, 1);
+  assert.ok(fs.existsSync(path.join(skillsDir(home), "master-zhiyi", "SKILL.md")));
+});
+
+test("uninstall removes an installed master", (t) => {
+  const { home, env } = tmpHome(t);
+  run(["install", "zhiyi"], env);
+  const { code } = run(["uninstall", "zhiyi"], env);
+  assert.equal(code, 0);
+  assert.ok(!fs.existsSync(path.join(skillsDir(home), "master-zhiyi")));
+});
+
+test("uninstall of a not-installed master exits non-zero", (t) => {
+  const { env } = tmpHome(t);
+  const { stdout, code } = run(["uninstall", "zhiyi"], env);
+  assert.equal(code, 1);
+  assert.match(stdout, /not installed/);
+});
+
+test("install --all installs every prebuilt master", (t) => {
+  const { home, env } = tmpHome(t);
+  const { code } = run(["install", "--all"], env);
+  assert.equal(code, 0);
+  for (const name of prebuiltMasters) {
+    assert.ok(
+      fs.existsSync(path.join(skillsDir(home), name, "SKILL.md")),
+      `missing ${name} after install --all`
+    );
+  }
+});
+
+test("unknown command exits non-zero", () => {
+  const { code } = run(["frobnicate"]);
+  assert.equal(code, 1);
+});


### PR DESCRIPTION
## Why

`bin/cli.mjs` is the one piece of code every npx user executes, and it was the only untested part of the repo. Reading it surfaced four real bugs, the worst being **the CLI is effectively broken on native Windows**.

## Fixes

1. **Windows path resolution** — `new URL(import.meta.url).pathname` yields `/C:/…` on Windows, so `prebuilt/` was never found and `npx master-skill list` printed *"No prebuilt masters found."* for every native-Windows user. Now uses `fileURLToPath`. `parseFrontmatter` also tolerates CRLF (autocrlf checkouts) so descriptions don't silently blank out.
2. **Stale files across upgrades** — `install` copied over an existing `~/.claude/skills/master-*/` without cleaning it; files renamed or removed upstream lingered as stale skill content. For a project whose selling point is citation fidelity, that's a product-level risk. `install` now clears the destination first.
3. **Exit codes** — failed install/uninstall (typo'd name, nothing available) exited 0. Scripted callers can now detect failure.
4. **`--version` flag + stale help text** — help hardcoded "v0.6+" (two releases behind); both now read `package.json`.
5. **Name validation** — install/uninstall names restricted to `[A-Za-z0-9_-]` so a path-traversal typo can never reach the `rmSync` sink or escape `prebuilt/`.

## Tests + CI

- `tests/cli.test.mjs`: 14 `node:test` integration tests, zero new dependencies — child-process spawns with HOME/USERPROFILE pointed at a temp dir, no mocks. Covers list, `--version`, short/full names, stale-file cleanup on reinstall, partial-failure exit codes, install **and** uninstall traversal rejection, a deterministic CRLF fixture, `--all`.
- New `cli-windows` job (windows-latest) runs the same suite — the regression net that would have caught bug 1 at introduction. Required-check names untouched.
- `on.push.paths` now includes `bin/**`, `tests/**`, `hooks/**`, `package.json` — direct pushes touching only the CLI previously triggered **zero** CI.

Reviewed pre-push (senior-reviewer pass); both Important findings (push-paths hole, missing uninstall-traversal test) are fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)