### PR TITLE
fix(scripts): resolve short master slug in offline helper scripts

### DIFF
--- a/scripts/_masterpaths.py
+++ b/scripts/_masterpaths.py
@@ -1,0 +1,32 @@
+"""Shared prebuilt-master directory resolution for the offline helper scripts.
+
+`prebuilt/` dirs are named `master-<slug>` (e.g. `master-huineng`), but the
+SKILL.md docs — and users — invoke the scripts with the short slug
+(`--master huineng`). Resolving only the literal value meant the documented
+short-name invocation silently found nothing for all 14 masters. This mirrors
+`resolveMasterDir` in `bin/cli.mjs`: try the value as given, then `master-<value>`.
+
+Callers are expected to validate the slug charset first (see `_SAFE_MASTER`),
+so this only does path resolution, never path-traversal guarding.
+"""
+import os
+
+PREBUILT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "prebuilt")
+
+
+def resolve_master_dir(master, base=PREBUILT):
+    """Return the prebuilt dir for `master`, or None if it doesn't exist.
+
+    Tries `<master>` first, then `master-<master>`, so both `huineng` and
+    `master-huineng` resolve to `prebuilt/master-huineng`.
+
+    Callers should still charset-check the slug (see `_SAFE_MASTER`), but as
+    defense in depth this never returns a path outside `base`: an absolute
+    value (`/etc`) or `..` traversal resolves outside and yields None.
+    """
+    base_abs = os.path.abspath(base)
+    for candidate in (master, f"master-{master}"):
+        path = os.path.join(base, candidate)
+        if os.path.isdir(path) and os.path.abspath(path).startswith(base_abs + os.sep):
+            return path
+    return None

--- a/scripts/cite.py
+++ b/scripts/cite.py
@@ -7,11 +7,11 @@ import os
 import re
 import sys
 
-BASE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "prebuilt")
+from _masterpaths import resolve_master_dir
 
-# master feeds into os.path.join(BASE, master, ...); restrict to a slug charset
-# so a value like "../../etc" can never read files outside prebuilt/. Mirrors
-# the isSafeName guard in bin/cli.mjs.
+# master feeds into os.path.join(...); restrict to a slug charset so a value
+# like "../../etc" can never read files outside prebuilt/. Mirrors the
+# isSafeName guard in bin/cli.mjs.
 _SAFE_MASTER = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
@@ -27,8 +27,8 @@ def parse_sections(text):
     return sections
 
 
-def find_citations(master, text):
-    sources_dir = os.path.join(BASE, master, "sources")
+def find_citations(master_dir, text):
+    sources_dir = os.path.join(master_dir, "sources")
     if not os.path.isdir(sources_dir):
         print(f"错误：找不到目录 {sources_dir}", file=sys.stderr)
         sys.exit(1)
@@ -66,7 +66,13 @@ def main():
         print(f"无效的 master ID：{args.master!r}（仅允许字母、数字、'-'、'_'）", file=sys.stderr)
         sys.exit(2)
 
-    results = find_citations(args.master, args.text)
+    master_dir = resolve_master_dir(args.master)
+    if master_dir is None:
+        print(f"找不到 master：{args.master!r}（试过 {args.master!r} 和 master-{args.master}）",
+              file=sys.stderr)
+        sys.exit(2)
+
+    results = find_citations(master_dir, args.text)
 
     if not results:
         print(f"未找到包含「{args.text}」的段落。")

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -7,11 +7,11 @@ import os
 import re
 import sys
 
-BASE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "prebuilt")
+from _masterpaths import resolve_master_dir
 
-# master feeds into os.path.join(BASE, master, ...); restrict to a slug charset
-# so a value like "../../etc" can never read files outside prebuilt/. Mirrors
-# the isSafeName guard in bin/cli.mjs.
+# master feeds into os.path.join(...); restrict to a slug charset so a value
+# like "../../etc" can never read files outside prebuilt/. Mirrors the
+# isSafeName guard in bin/cli.mjs.
 _SAFE_MASTER = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
@@ -27,12 +27,12 @@ def parse_sections(text):
     return sections
 
 
-def search(master, query, brief=False):
+def search(master_dir, query, brief=False):
     keywords = query.split()
     results = []
 
     for subdir in ("sources", "references"):
-        dirpath = os.path.join(BASE, master, subdir)
+        dirpath = os.path.join(master_dir, subdir)
         if not os.path.isdir(dirpath):
             continue
         for fname in sorted(os.listdir(dirpath)):
@@ -69,7 +69,13 @@ def main():
         print(f"无效的 master ID：{args.master!r}（仅允许字母、数字、'-'、'_'）", file=sys.stderr)
         sys.exit(2)
 
-    results = search(args.master, args.q, args.brief)
+    master_dir = resolve_master_dir(args.master)
+    if master_dir is None:
+        print(f"找不到 master：{args.master!r}（试过 {args.master!r} 和 master-{args.master}）",
+              file=sys.stderr)
+        sys.exit(2)
+
+    results = search(master_dir, args.q, args.brief)
 
     if not results:
         print(f"未找到包含「{args.q}」的段落。")

--- a/scripts/verify_citations.py
+++ b/scripts/verify_citations.py
@@ -24,11 +24,11 @@ import os
 import re
 import sys
 
-BASE = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "prebuilt")
+from _masterpaths import resolve_master_dir
 
-# master feeds into os.path.join(BASE, master, ...); restrict to a slug charset
-# so a value like "../../etc" can never read files outside prebuilt/. Mirrors
-# the isSafeName guard in bin/cli.mjs and scripts/query.py.
+# master feeds into path resolution; restrict to a slug charset so a value like
+# "../../etc" can never read files outside prebuilt/. Mirrors the isSafeName
+# guard in bin/cli.mjs and scripts/query.py.
 _SAFE_MASTER = re.compile(r"^[A-Za-z0-9_-]+$")
 
 # CBETA id 形态:T48n2008 / T08n0235(藏经卷+n+编号),及 API 返回的 X1218 / X0303
@@ -46,14 +46,10 @@ def load_declared_ids(master: str) -> set[str]:
     """读 prebuilt/<master>/meta.json,返回声明的离线 cbeta_id 集合。"""
     if not _SAFE_MASTER.match(master):
         raise ValueError(f"无效的 master ID：{master!r}（仅允许字母、数字、'-'、'_'）")
-    # 兼容 "huineng" 与 "master-huineng" 两种写法,镜像 bin/cli.mjs 的 resolveMasterDir。
-    for cand in (master, f"master-{master}"):
-        meta_path = os.path.join(BASE, cand, "meta.json")
-        if os.path.isfile(meta_path):
-            break
-    else:
-        raise FileNotFoundError(f"找不到 master：{master!r}（试过 {master!r} 和 master-{master!r}）")
-    with open(meta_path, encoding="utf-8") as f:
+    master_dir = resolve_master_dir(master)  # 兼容 "huineng" / "master-huineng"
+    if master_dir is None:
+        raise FileNotFoundError(f"找不到 master：{master!r}（试过 {master!r} 和 master-{master}）")
+    with open(os.path.join(master_dir, "meta.json"), encoding="utf-8") as f:
         meta = json.load(f)
     ids: set[str] = set()
     for src in meta.get("sources", []):

--- a/tests/test_master_paths.py
+++ b/tests/test_master_paths.py
@@ -1,0 +1,68 @@
+"""Tests for scripts/_masterpaths.py and the short-name resolution fix
+in query.py / cite.py (the documented `--master <slug>` invocation used to
+silently find nothing because dirs are named `master-<slug>`)."""
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+_masterpaths = importlib.import_module("_masterpaths")
+resolve_master_dir = _masterpaths.resolve_master_dir
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def test_resolve_short_name():
+    d = resolve_master_dir("huineng")
+    assert d is not None and Path(d).name == "master-huineng"
+
+
+def test_resolve_full_name():
+    d = resolve_master_dir("master-huineng")
+    assert d is not None and Path(d).name == "master-huineng"
+
+
+def test_resolve_missing_returns_none():
+    assert resolve_master_dir("nonexistent-master") is None
+
+
+def test_resolve_never_escapes_base():
+    """Defense in depth: even unvalidated traversal / abs paths resolve to None,
+    never to a dir outside prebuilt/ (callers also charset-gate, this is backup)."""
+    assert resolve_master_dir("../scripts") is None
+    assert resolve_master_dir("/etc") is None
+    assert resolve_master_dir("") is None
+
+
+def _run(script, *args):
+    return subprocess.run(
+        [sys.executable, str(REPO / "scripts" / script), *args],
+        capture_output=True, text=True,
+    )
+
+
+def test_query_short_name_now_finds_results():
+    """Regression: `query.py --master huineng` (short, as SKILL.md documents)
+    must return results, not silently empty."""
+    r = _run("query.py", "--master", "huineng", "--q", "见性", "--brief")
+    assert r.returncode == 0
+    assert "未找到" not in r.stdout
+    assert "→" in r.stdout  # at least one [section] → file line
+
+
+def test_cite_short_name_now_works():
+    r = _run("cite.py", "--master", "huineng", "--text", "见性")
+    assert r.returncode == 0
+
+
+def test_query_unknown_master_errors_not_silent():
+    """Unknown master should error (exit 2), not exit 0 with an empty result."""
+    r = _run("query.py", "--master", "nonexistent-master", "--q", "x")
+    assert r.returncode == 2
+    assert "找不到 master" in r.stderr
+
+
+def test_query_rejects_traversal():
+    r = _run("query.py", "--master", "../../etc", "--q", "x")
+    assert r.returncode == 2


### PR DESCRIPTION
## 真 bug:离线辅助脚本按文档调用对全部 14 位都失效

每个 master 的 SKILL.md 都用**短名**调用离线脚本(`scripts/query.py --master huineng`、`scripts/cite.py --text … --master huineng`),但脚本直接把短名拼到 `prebuilt/` 下,而目录名是 `master-<slug>`。结果:

- `query.py --master huineng` → **静默返回空 + exit 0**(去找不存在的 `prebuilt/huineng/`)
- `cite.py --master huineng` → 报"找不到目录"
- `--master master-huineng`(全名)才正常 —— 但没有 SKILL.md 这么写(除 zhiyi 外)

### 与 #49 的耦合
huineng 新决策树有一条"`sources/` 检索为空 → 上 live"。因为 `query.py` 短名**永远**返回空,这条会**永远误触发 live**,破坏"离线优先"。所以这个修复对 #49 的正确性也是必要的。

## 改动
- 新增 `scripts/_masterpaths.py`,`resolve_master_dir()` 先试 `<slug>` 再试 `master-<slug>`,镜像 `bin/cli.mjs` 的 `resolveMasterDir`。
- `query.py` / `cite.py` / `verify_citations.py` 共用它(此前三处重复)。
- `query.py` 对未知 master 现在**明确报错 exit 2**,不再静默 exit 0 空结果。

## 测试
- 新增 `tests/test_master_paths.py`:解析单测 + CLI 级子进程回归(短名现在真返回结果、未知 master 报错、traversal 被拒)。
- `pytest` 48 passed / 6 skipped;`npm test` 全链绿。

> 注(留作后续决策,不在本 PR):这些脚本仍**不随 npm `cli.mjs install` 进 `~/.claude/skills/`**,故仅在 repo / git-clone / CI 渠道可用。是否要把它们打进技能目录、或调整 SKILL.md 措辞,另议。

🤖 Generated with [Claude Code](https://claude.com/claude-code)